### PR TITLE
Add a filter to avoid wrapping in some posts/pages

### DIFF
--- a/content-bootstrap.php
+++ b/content-bootstrap.php
@@ -83,7 +83,13 @@ public function shortcode_badge($p, $content)
 
 public function the_content($content)
 {
-    return '<div class="content-bootstrap-area">'.$content.'</div>';
+    $wrap = apply_filters( 'content_bootstrap_wrap', true );
+    if ( $wrap ) {
+        return '<div class="content-bootstrap-area">'.$content.'</div>';
+    } else {
+        return $content;
+    }
+    
 }
 
 public function mce_buttons_2($buttons)


### PR DESCRIPTION
I want to disable content-bootstrap function is some pages like contact form pages.

Usage of this filter hook would be like below.

```
add_filter( 'content_bootstrap_wrap', 'no_content_bootstrap_wrap' );
function no_content_bootstrap_wrap( $bool ) {
    if ( is_page_template( 'form.php' ) ) {
        return false;
    }
    return true;
}
```
